### PR TITLE
feat: support live custom web CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Karere will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Custom Web CSS**: optionally load `$XDG_CONFIG_HOME/karere/custom.css` into WhatsApp Web. The stylesheet is monitored and reapplied live across all isolated account browsers, including atomic file replacements.
+
 ## [4.2.5] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ For the full release history, see [CHANGELOG.md](CHANGELOG.md).
 - **Granular Notification Controls**: Master toggle, plus individual settings for sound on/off, previews, and downloads
 - **Privacy Settings**: Control message previews and system tray behavior
 - **Theme Selection**: Light, Dark, or System preference
+- **Custom Web CSS**: Optionally load `$XDG_CONFIG_HOME/karere/custom.css` into WhatsApp Web
 - **Permission Management**: Persistent controls for Microphone and Notifications
 - **Startup Control**: Toggle automatic launch on login
 
@@ -140,6 +141,15 @@ Access preferences through the application menu or keyboard shortcut (`Ctrl+,`) 
 - **Accessibility**: Keyboard shortcuts, focus indicators, high contrast, reduced motion, zoom settings, screen reader optimization
 - **Notifications**: Native notification preferences, preview settings, background notifications
 - **Spell Checking**: Multi-language spell checking with auto-detect
+
+### Custom Web CSS
+
+Karere optionally loads `$XDG_CONFIG_HOME/karere/custom.css` into WhatsApp Web. The file is
+watched while Karere is running, so saving a new stylesheet updates every isolated account
+without restarting the application. If `XDG_CONFIG_HOME` is unset, the native default is
+`~/.config`; sandboxed installations such as Flatpak resolve it inside the application's
+sandbox-specific config directory instead. The feature is generic and can be used with any
+CSS generator or editor.
 
 ### Keyboard Shortcuts
 

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -12,6 +12,8 @@
 
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::io::ErrorKind;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
@@ -45,8 +47,7 @@ pub fn set_dark_preference(dark: bool) {
 /// [`PREFERS_DARK`]. Sent on attach/load and on live theme changes. (#160)
 pub fn apply_color_scheme(host: &BrowserHost) {
     // Out-of-band id range so it can't collide with a session's bumped ids.
-    static CTR: AtomicU32 = AtomicU32::new(2_000_000);
-    let id = CTR.fetch_add(1, Ordering::Relaxed);
+    let id = next_out_of_band_id();
     let scheme = if PREFERS_DARK.load(Ordering::Relaxed) {
         "dark"
     } else {
@@ -222,6 +223,90 @@ const PAGE_PATCH: &str = r#"
 })();
 "#;
 
+const CUSTOM_CSS_STYLE_ID: &str = "karere-custom-css";
+
+/// Return the optional user stylesheet path. The path follows the XDG config
+/// directory, as resolved by GLib, so `$XDG_CONFIG_HOME` is honored.
+pub fn custom_css_path() -> PathBuf {
+    glib::user_config_dir().join("karere").join("custom.css")
+}
+
+/// Build the page expression that creates or updates Karere's stylesheet.
+/// `css` is encoded as a JSON string so arbitrary CSS cannot alter the JS
+/// expression being evaluated by CDP.
+fn custom_css_script(css: Option<&str>) -> String {
+    let style_id = json_string(CUSTOM_CSS_STYLE_ID);
+    match css {
+        Some(css) => format!(
+            "(function(){{\
+                var style=document.getElementById({style_id});\
+                if(!style){{\
+                    style=document.createElement('style');\
+                    style.id={style_id};\
+                    var parent=document.head||document.documentElement;\
+                    if(!parent)return;\
+                    parent.appendChild(style);\
+                }}\
+                style.textContent={};\
+            }})();",
+            json_string(css)
+        ),
+        None => format!(
+            "(function(){{\
+                var style=document.getElementById({style_id});\
+                if(style)style.remove();\
+            }})();"
+        ),
+    }
+}
+
+/// Read the optional user stylesheet. A missing file is a valid disabled state;
+/// other I/O errors leave the currently injected stylesheet unchanged.
+fn read_custom_css() -> std::io::Result<Option<String>> {
+    match std::fs::read_to_string(custom_css_path()) {
+        Ok(css) => Ok(Some(css)),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Load and serialize the optional stylesheet once for reuse across browsers.
+pub(crate) fn load_custom_css_script() -> std::io::Result<(String, usize)> {
+    let css = read_custom_css()?;
+    let css_len = css.as_deref().map_or(0, str::len);
+    Ok((custom_css_script(css.as_deref()), css_len))
+}
+
+/// Inject a previously loaded stylesheet script in the page's main realm.
+pub(crate) fn apply_custom_css_script(host: &BrowserHost, script: &str, css_len: usize) {
+    log::debug!("cdp: applying custom CSS ({} bytes)", css_len);
+    let id = next_out_of_band_id();
+    send(
+        host,
+        &json_msg(id, "Runtime.evaluate", &eval_params(script)),
+    );
+}
+
+/// Inject or remove the optional user stylesheet in the page's main realm.
+/// This is intentionally generic: any CSS generator can produce the same
+/// `$XDG_CONFIG_HOME/karere/custom.css` file.
+pub fn apply_custom_css(host: &BrowserHost) {
+    let (script, css_len) = match load_custom_css_script() {
+        Ok(payload) => payload,
+        Err(e) => {
+            log::warn!("cdp: failed to read custom CSS: {e}");
+            return;
+        }
+    };
+    apply_custom_css_script(host, &script, css_len);
+}
+
+/// Out-of-band IDs avoid collisions with the per-browser observer state.
+fn next_out_of_band_id() -> u32 {
+    static CTR: AtomicU32 = AtomicU32::new(2_000_000);
+    CTR.fetch_add(1, Ordering::Relaxed)
+}
+
 /// Per-browser CDP state. Lives on the CEF UI thread (single-threaded), so a
 /// plain `RefCell` suffices — no locking.
 struct State {
@@ -324,6 +409,9 @@ fn arm(host: &BrowserHost, state: &Rc<RefCell<State>>) {
         host,
         &json_msg(id, "Runtime.evaluate", &eval_params(PAGE_PATCH)),
     );
+    // Inject optional user CSS after the existing page patch. This is also
+    // reapplied for each new execution context below (page reloads).
+    apply_custom_css(host);
     // Match the web content's color scheme to the Karere theme (#160).
     apply_color_scheme(host);
     // Read the current WhatsApp locale; `handle` reconciles it against the
@@ -393,6 +481,9 @@ fn handle(state: &Rc<RefCell<State>>, host: &BrowserHost, v: &serde_json::Value)
     // Page finished loading (page realm only) — now the rendered language is
     // set, so re-probe and reconcile against the override.
     if method == "Page.loadEventFired" && session.is_none() {
+        // The execution context may have appeared before document.head was
+        // available; this late pass guarantees the stylesheet has a DOM target.
+        apply_custom_css(host);
         send_lang_probe(host, state);
         return;
     }
@@ -433,6 +524,9 @@ fn handle(state: &Rc<RefCell<State>>, host: &BrowserHost, v: &serde_json::Value)
                     host,
                     &json_msg(id, "Runtime.evaluate", &eval_params(PAGE_PATCH)),
                 );
+                // The new page realm lost the stylesheet along with the page
+                // patch, so apply the current file contents again.
+                apply_custom_css(host);
             }
             Some(s) if state.borrow().sw_sessions.contains(s) => {
                 let s = s.to_owned();
@@ -611,4 +705,31 @@ fn json_msg_sess(id: u32, method: &str, params: &str, session: &str) -> String {
 
 fn json_string(s: &str) -> String {
     serde_json::Value::String(s.to_owned()).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CUSTOM_CSS_STYLE_ID, custom_css_script};
+
+    #[test]
+    fn custom_css_script_updates_a_dedicated_style_element() {
+        let css = "body { content: `literal`; }\\n:root { --value: \"quoted\"; } ${not_js}";
+        let script = custom_css_script(Some(css));
+        let encoded_css = serde_json::to_string(css).unwrap();
+
+        assert!(script.contains("document.createElement('style')"));
+        assert!(script.contains(&format!(
+            "document.getElementById(\"{CUSTOM_CSS_STYLE_ID}\")"
+        )));
+        assert!(script.contains(&format!("style.textContent={encoded_css}")));
+        assert!(script.contains("document.head||document.documentElement"));
+    }
+
+    #[test]
+    fn custom_css_script_removes_the_style_element_when_disabled() {
+        let script = custom_css_script(None);
+
+        assert!(script.contains("if(style)style.remove()"));
+        assert!(!script.contains("style.textContent"));
+    }
 }

--- a/src/web_view.rs
+++ b/src/web_view.rs
@@ -1,5 +1,35 @@
-use gtk::glib;
 use gtk::subclass::prelude::*;
+use gtk::{gio, glib};
+
+/// Whether a directory-monitor event concerns the generated custom stylesheet.
+/// Both paths matter for atomic renames, where `other_file` may be the target.
+fn custom_css_event_is_relevant(
+    file: &gio::File,
+    other_file: Option<&gio::File>,
+    file_name: &str,
+    event: gio::FileMonitorEvent,
+) -> bool {
+    use gio::prelude::FileExt;
+
+    let content_event = matches!(
+        event,
+        gio::FileMonitorEvent::Changed
+            | gio::FileMonitorEvent::ChangesDoneHint
+            | gio::FileMonitorEvent::Deleted
+            | gio::FileMonitorEvent::Created
+            | gio::FileMonitorEvent::AttributeChanged
+            | gio::FileMonitorEvent::Moved
+            | gio::FileMonitorEvent::Renamed
+            | gio::FileMonitorEvent::MovedIn
+            | gio::FileMonitorEvent::MovedOut
+    );
+    content_event
+        && std::iter::once(file).chain(other_file).any(|candidate| {
+            candidate
+                .basename()
+                .is_some_and(|name| name.to_string_lossy() == file_name)
+        })
+}
 
 glib::wrapper! {
     pub struct KarereWebView(ObjectSubclass<imp::KarereWebView>)
@@ -106,6 +136,12 @@ impl KarereWebView {
         for h in &hosts {
             crate::cdp::apply_color_scheme(h);
         }
+    }
+
+    /// Reinject the current user stylesheet into every live account browser.
+    /// Called by the custom CSS file monitor after a debounced file change.
+    pub fn reapply_custom_css(&self) {
+        self.imp().reapply_custom_css();
     }
 
     pub fn shared(&self) -> crate::handlers::SharedRef {
@@ -528,9 +564,9 @@ mod imp {
     };
     use gl::types::{GLenum, GLint, GLuint};
     use glib::subclass::Signal;
-    use gtk::glib;
     use gtk::prelude::*;
     use gtk::subclass::prelude::*;
+    use gtk::{gio, glib};
     use once_cell::sync::Lazy;
     use parking_lot::Mutex;
     use std::cell::RefCell;
@@ -556,6 +592,11 @@ mod imp {
         /// Per-account in-process CDP notification-bridge registrations. Held
         /// alive for the browser's lifetime; dropping one detaches the observer.
         pub cdp_registrations: RefCell<HashMap<String, cef::Registration>>,
+        /// Directory monitor for the optional user stylesheet. Watching the
+        /// directory handles atomic replacement by template generators.
+        pub custom_css_monitor: RefCell<Option<gio::FileMonitor>>,
+        /// Debounced custom CSS refresh source, if a file event is pending.
+        pub custom_css_reload: RefCell<Option<glib::SourceId>>,
         /// RequestContexts kept alive until the browser is created against them
         /// (in their init callback). Keyed by account id.
         pub pending_contexts: Mutex<HashMap<String, RequestContext>>,
@@ -758,6 +799,9 @@ mod imp {
             unsafe {
                 self.init_gl();
             }
+            if !self.devtools.load(Ordering::Relaxed) {
+                self.start_custom_css_monitor();
+            }
             self.bootstrap_pool();
 
             // Follow scale changes (e.g. dragging between monitors of different
@@ -880,6 +924,9 @@ mod imp {
         }
 
         pub fn close_browser(&self) {
+            if let Some(source) = self.custom_css_reload.borrow_mut().take() {
+                source.remove();
+            }
             #[cfg(test)]
             if self.suppress_browser_creation.load(Ordering::Acquire) {
                 self.fallback_test_events.borrow_mut().push(("close", None));
@@ -917,6 +964,118 @@ mod imp {
             }
             *self.browser.lock() = None;
             *self.life_span.lock() = None;
+        }
+
+        /// Start watching the configuration directory for generated CSS updates.
+        /// The directory, rather than only the file, is monitored because a
+        /// generator may write a temporary file and atomically rename it into place.
+        fn start_custom_css_monitor(&self) {
+            use gio::prelude::{FileExt, FileMonitorExt};
+
+            if self.custom_css_monitor.borrow().is_some() {
+                return;
+            }
+            let css_path = crate::cdp::custom_css_path();
+            let Some(directory) = css_path.parent() else {
+                log::warn!("custom CSS path has no parent: {}", css_path.display());
+                return;
+            };
+            if let Err(e) = std::fs::create_dir_all(directory) {
+                log::warn!(
+                    "failed to create custom CSS directory {}: {e}",
+                    directory.display()
+                );
+                return;
+            }
+            let Some(file_name) = css_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_owned)
+            else {
+                log::warn!(
+                    "custom CSS path has no valid file name: {}",
+                    css_path.display()
+                );
+                return;
+            };
+
+            let directory_file = gio::File::for_path(directory);
+            let monitor = match directory_file
+                .monitor_directory(gio::FileMonitorFlags::NONE, gio::Cancellable::NONE)
+            {
+                Ok(monitor) => monitor,
+                Err(e) => {
+                    log::warn!(
+                        "failed to monitor custom CSS directory {}: {e}",
+                        directory.display()
+                    );
+                    return;
+                }
+            };
+            let weak = self.obj().downgrade();
+            let watched_name = file_name.clone();
+            monitor.connect_changed(move |_monitor, file, other_file, event| {
+                if !super::custom_css_event_is_relevant(file, other_file, &watched_name, event) {
+                    return;
+                }
+                let Some(widget) = weak.upgrade() else {
+                    return;
+                };
+                widget.imp().schedule_custom_css_reload();
+            });
+            *self.custom_css_monitor.borrow_mut() = Some(monitor);
+            log::info!("watching custom CSS file {}", css_path.display());
+        }
+
+        /// Schedule one stylesheet refresh for a burst of filesystem events.
+        fn schedule_custom_css_reload(&self) {
+            if let Some(source) = self.custom_css_reload.borrow_mut().take() {
+                source.remove();
+            }
+            let weak = self.obj().downgrade();
+            let source =
+                glib::timeout_add_local_once(std::time::Duration::from_millis(100), move || {
+                    let Some(widget) = weak.upgrade() else {
+                        return;
+                    };
+                    let imp = widget.imp();
+                    imp.custom_css_reload.borrow_mut().take();
+                    imp.reapply_custom_css();
+                });
+            *self.custom_css_reload.borrow_mut() = Some(source);
+        }
+
+        /// Reinject the current stylesheet into all account browsers. Clone the
+        /// browser handles first so CDP sends never happen while a pool lock is held.
+        pub fn reapply_custom_css(&self) {
+            let (script, css_len) = match crate::cdp::load_custom_css_script() {
+                Ok(payload) => payload,
+                Err(e) => {
+                    log::warn!("failed to read custom CSS after change: {e}");
+                    return;
+                }
+            };
+            let browsers: Vec<Browser> = {
+                let pooled = self.browsers.lock();
+                if pooled.is_empty() {
+                    self.browser.lock().clone().into_iter().collect()
+                } else {
+                    pooled.values().cloned().collect()
+                }
+            };
+            if browsers.is_empty() {
+                log::debug!("custom CSS changed with no live browsers");
+                return;
+            }
+            log::info!(
+                "custom CSS changed; reinjecting into {} browser(s)",
+                browsers.len()
+            );
+            for browser in browsers {
+                if let Some(host) = browser.host() {
+                    crate::cdp::apply_custom_css_script(&host, &script, css_len);
+                }
+            }
         }
 
         /// Recreate this widget's browser pool with CEF shared textures disabled.
@@ -4198,5 +4357,48 @@ mod zoom_tests {
     fn clamp_above_max() {
         let back = cef_to_linear(linear_to_cef(5.0));
         assert!((back - ZOOM_MAX).abs() < 1e-9, "clamp 5.0 -> {back}");
+    }
+}
+
+#[cfg(test)]
+mod custom_css_monitor_tests {
+    use super::custom_css_event_is_relevant;
+    use gtk::gio;
+
+    #[test]
+    fn matches_target_and_atomic_replace_events() {
+        let target = gio::File::for_path("/tmp/custom.css");
+        let temporary = gio::File::for_path("/tmp/.custom.css.tmp");
+
+        assert!(custom_css_event_is_relevant(
+            &target,
+            None,
+            "custom.css",
+            gio::FileMonitorEvent::Changed,
+        ));
+        assert!(custom_css_event_is_relevant(
+            &target,
+            None,
+            "custom.css",
+            gio::FileMonitorEvent::MovedIn,
+        ));
+        assert!(custom_css_event_is_relevant(
+            &temporary,
+            Some(&target),
+            "custom.css",
+            gio::FileMonitorEvent::Moved,
+        ));
+        assert!(!custom_css_event_is_relevant(
+            &temporary,
+            None,
+            "custom.css",
+            gio::FileMonitorEvent::Changed,
+        ));
+        assert!(!custom_css_event_is_relevant(
+            &target,
+            None,
+            "custom.css",
+            gio::FileMonitorEvent::PreUnmount,
+        ));
     }
 }


### PR DESCRIPTION
## What

Add optional user CSS injection for WhatsApp Web, with live reload while Karere is running.

Related to #98, but this PR deliberately does not bundle or maintain a WhatsApp theme. It only provides a generic user CSS injection and live-reload mechanism.

## Details

- Loads `$XDG_CONFIG_HOME/karere/custom.css` when a browser execution context is ready.
- Uses a dedicated `<style id="karere-custom-css">` element, so updates replace only Karere's stylesheet.
- Encodes CSS as JSON before evaluating it through CDP.
- Reapplies the stylesheet after page reloads, including a `Page.loadEventFired` fallback, and to every isolated account browser.
- Monitors the configuration directory with `gio::FileMonitor`, handling edits, deletion, creation, and atomic replacement.
- Debounces filesystem event bursts by 100 ms.
- Reads and serializes the stylesheet once before applying the same snapshot to all account browsers during a live reload.
- Missing or deleted CSS removes the injected stylesheet.
- The feature is generator-agnostic; it does not depend on Noctalia or any other theme tool.

## Tests

- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace --all-targets`
- `cargo check --locked --workspace --all-targets`
- Manual live-reload check with two active account browsers.
- `cargo fmt --all -- --check` produces the same diagnostics as `upstream/main`; no additional formatter differences are introduced by this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Custom Web CSS support for WhatsApp Web using `custom.css`.
  - Changes to the stylesheet are detected and applied live across open account browsers.
  - Styles are also applied when pages load or new browser sessions open.
  - Removing the stylesheet disables custom styling.

- **Documentation**
  - Added setup and usage guidance, including configuration path fallbacks and Flatpak-specific locations.
  - Documented compatibility with CSS generators and editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->