### PR TITLE
Enable CEF sandbox outside Flatpak

### DIFF
--- a/src/cef_runtime.rs
+++ b/src/cef_runtime.rs
@@ -147,10 +147,11 @@ wrap_app! {
             cmd.append_switch(Some(&"no-startup-window".into()));
             cmd.append_switch(Some(&"noerrdialogs".into()));
             cmd.append_switch(Some(&"hide-crash-restore-bubble".into()));
-            // Single-webview app: zygote fork-sharing wins are negligible.
-            // Disabling keeps a flat, debuggable process tree (forked renderers
-            // are otherwise mislabeled --type=zygote).
-            cmd.append_switch(Some(&"no-zygote".into()));
+            // Keep the flat process tree only in Flatpak, where the CEF
+            // sandbox is disabled. Native sandboxing requires zygote.
+            if std::env::var_os("FLATPAK_ID").is_some() {
+                cmd.append_switch(Some(&"no-zygote".into()));
+            }
             // Memory: turn off the site-isolation field trials too (the
             // disable-features list above only covers the static features), so
             // WhatsApp's cross-origin frames don't each fork their own renderer.
@@ -347,7 +348,11 @@ pub fn initialize_browser_process(args: &Args, app: &mut App) -> Result<()> {
     let settings = Settings {
         windowless_rendering_enabled: 1,
         external_message_pump: 1,
-        no_sandbox: 1,
+        no_sandbox: if std::env::var_os("FLATPAK_ID").is_some() {
+            1
+        } else {
+            0
+        },
         root_cache_path: cef::CefString::from(root_cache.to_string_lossy().as_ref()),
         locale: cef::CefString::from(cef_locale.as_str()),
         accept_language_list: cef::CefString::from(accept_lang.as_str()),

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -69,6 +69,12 @@ pub fn ui_locales() -> Vec<(String, String)> {
 /// locale. Schema-guarded: returns `None` rather than aborting if the GSchema
 /// is not installed (can happen very early in `main` on uninstalled dev runs).
 pub fn override_locale() -> Option<String> {
+    // CEF zygotes must remain single-threaded before forking. Reading the
+    // GSettings below can start GLib/GIO worker threads in subprocesses.
+    if std::env::args().any(|arg| arg.starts_with("--type=")) {
+        return None;
+    }
+
     let source = gio::SettingsSchemaSource::default()?;
     source.lookup(APP_ID, true)?;
     let value = gio::Settings::new(APP_ID).string("app-language");

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -71,7 +71,7 @@ pub fn ui_locales() -> Vec<(String, String)> {
 pub fn override_locale() -> Option<String> {
     // CEF zygotes must remain single-threaded before forking. Reading the
     // GSettings below can start GLib/GIO worker threads in subprocesses.
-    if std::env::args().any(|arg| arg.starts_with("--type=")) {
+    if std::env::args_os().any(|arg| arg.to_string_lossy().starts_with("--type=")) {
         return None;
     }
 


### PR DESCRIPTION
## Summary

Enable the CEF/Chromium sandbox when Karere is running outside Flatpak,
while preserving the existing Flatpak behavior.

Karere currently disables the CEF sandbox globally. The workaround is
needed for the current Flatpak setup, but it is not necessary when Karere
is already running directly on the host, including the documented local
development workflow using `cargo run`.

This PR does not add or imply support for non-Flatpak packaging or
installation.

## Changes

- Disable the CEF sandbox only when `FLATPAK_ID` is present.
- Add `--no-zygote` only under Flatpak. Native Chromium sandboxing
  requires the normal zygote process.
- Avoid reading GSettings from CEF subprocesses. `gio::Settings` can
  start GLib/GIO worker threads, while the Chromium zygote must remain
  single-threaded during sandbox initialization.

## Behavior

| Environment | CEF sandbox | `--no-zygote` |
|-------------|-------------|---------------|
| Flatpak | Disabled | Yes |
| Outside Flatpak | Enabled | No |

Flatpak behavior is unchanged.

## Scope

This is intentionally narrower than #135.

It does not add native installation, packaging, portal, autostart,
app-ID, PATH or distribution support. It only changes CEF's sandbox
configuration when Karere is already being executed outside Flatpak.

## Testing

Tested outside Flatpak with:

- release build with the local CEF runtime
- `cargo clippy --release --locked`
- `cargo test --release --locked --bin karere` (87 passed)
- application startup and CEF initialization
- WhatsApp Web loading with existing sessions
- CEF subprocess startup with the normal zygote
- no native `--no-sandbox` or `--no-zygote` command-line switches
- `/proc` verification of sandboxed descendants: `NoNewPrivs=1`,
  `Seccomp=2` with one filter, zero effective capabilities, and isolated
  user/pid/net namespaces



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application startup and runtime compatibility in Flatpak installations.
  - Native installations now retain their standard runtime behavior.
  - Improved locale handling during startup, including safer processing of unusual command-line arguments.
  - Reduced the risk of startup failures when configuring language preferences in CEF subprocesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->